### PR TITLE
Update gcloud sdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ FROM google/cloud-sdk:$GCLOUD_SDK_VERSION
 MAINTAINER Singularities
 
 # Install Java 8 for Datastore emulator
-RUN apk --update add openjdk8-jre
-RUN gcloud components install cloud-datastore-emulator beta --quiet
+RUN apk add --update --no-cache openjdk8-jre &&\
+    gcloud components install cloud-datastore-emulator beta --quiet
 
 # Volume to persist Datastore data
 VOLUME /opt/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Version. Can change in build progress
-ARG GCLOUD_SDK_VERSION=183.0.0-alpine
+ARG GCLOUD_SDK_VERSION=198.0.0-alpine
 
 # Use google cloud sdk
 FROM google/cloud-sdk:$GCLOUD_SDK_VERSION


### PR DESCRIPTION
Hi there,

Just a quick PR bumping up the default Google Cloud SDK to 198.0.0 and collapsing the two RUN directives into one. 

Cheers,

Sid