### PR TITLE
Update Gcloud SDK version to 293.0.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Version. Can change in build progress
-ARG GCLOUD_SDK_VERSION=198.0.0-alpine
+ARG GCLOUD_SDK_VERSION=293.0.0-alpine
 
 # Use google cloud sdk
 FROM google/cloud-sdk:$GCLOUD_SDK_VERSION


### PR DESCRIPTION
This PR bumps up the Gcloud SDK version to 293.0 and allows to take advantage of recently introduced emulator import/export functionality: https://cloud.google.com/datastore/docs/tools/emulator-export-import 